### PR TITLE
Fix license typos and use SPDX short identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Dehydration is an thirst mod.
 Dehydration is a mod built for the [Fabric Loader](https://fabricmc.net/). It requires [Fabric API](https://www.curseforge.com/minecraft/mc-mods/fabric-api) and [Cloth Config API](https://www.curseforge.com/minecraft/mc-mods/cloth-config) to be installed separately; all other dependencies are installed with the mod.
 
 ### License
-Dehydration is licensed under GLPv3.
+Dehydration is licensed under GPLv3.

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
     "sources": "https://github.com/Globox1997/Dehydration",
     "issues": "https://github.com/Globox1997/Dehydration/issues"
   },
-  "license": "GPLv3",
+  "license": "GPL-3.0-or-later",
   "icon": "assets/dehydration/icon.png",
   "environment": "*",
   "entrypoints": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
     "sources": "https://github.com/Globox1997/Dehydration",
     "issues": "https://github.com/Globox1997/Dehydration/issues"
   },
-  "license": "GLPv3",
+  "license": "GPLv3",
   "icon": "assets/dehydration/icon.png",
   "environment": "*",
   "entrypoints": {


### PR DESCRIPTION
The [Fabric wiki](https://fabricmc.net/wiki/documentation:fabric_mod_json_spec#optional_fields_metadata) suggests using a SPDX short identifier to help with automated software. I include the suggested change, and I also changed "GLPv3" to "GPLv3" which I believe is a typo.