### PR TITLE
Flash thirst bar when holding drinkable item in offhand

### DIFF
--- a/src/main/java/net/dehydration/thirst/ThirstHudRender.java
+++ b/src/main/java/net/dehydration/thirst/ThirstHudRender.java
@@ -39,7 +39,7 @@ public class ThirstHudRender {
                         if (!playerEntity.getMainHandStack().isEmpty() && !playerEntity.getMainHandStack().getTooltipData().isEmpty()
                                 && playerEntity.getMainHandStack().getTooltipData().get() instanceof ThirstTooltipData) {
                             itemStack = playerEntity.getMainHandStack();
-                        } else if (playerEntity.getOffHandStack().isEmpty() && !playerEntity.getOffHandStack().getTooltipData().isEmpty()
+                        } else if (!playerEntity.getOffHandStack().isEmpty() && !playerEntity.getOffHandStack().getTooltipData().isEmpty()
                                 && playerEntity.getOffHandStack().getTooltipData().get() instanceof ThirstTooltipData) {
                             itemStack = playerEntity.getOffHandStack();
                         }


### PR DESCRIPTION
The check for whether the offhand item had a thirst value was inverted, so the bar never flashed when holding e.g. a flask in the offhand.