### PR TITLE
Register purified water bucket as fluid storage

### DIFF
--- a/src/main/java/net/dehydration/init/FluidInit.java
+++ b/src/main/java/net/dehydration/init/FluidInit.java
@@ -1,9 +1,16 @@
 package net.dehydration.init;
 
 import net.dehydration.fluid.PurifiedWaterFluid;
+import net.dehydration.item.PurifiedBucket;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.fluid.base.EmptyItemFluidStorage;
+import net.fabricmc.fabric.api.transfer.v1.fluid.base.FullItemFluidStorage;
 import net.minecraft.fluid.FlowableFluid;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
+import net.minecraft.item.Items;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 
@@ -12,7 +19,27 @@ public class FluidInit {
     public static final FlowableFluid PURIFIED_FLOWING_WATER = register("dehydration:purified_flowing_water", new PurifiedWaterFluid.Flowing());
     public static final FlowableFluid PURIFIED_WATER = register("dehydration:purified_water", new PurifiedWaterFluid.Still());
 
-    public static void init() {
+    public static void init()
+    {
+        initFluidStorage();
+    }
+
+    private static void initFluidStorage()
+    {
+        FluidStorage.GENERAL_COMBINED_PROVIDER.register(context ->
+        {
+            if(context.getItemVariant().getItem() instanceof PurifiedBucket bucketItem)
+            {
+                Fluid bucketFluid = FluidInit.PURIFIED_WATER;
+                if(bucketFluid != null && bucketFluid.getBucketItem() == bucketItem)
+                {
+                    return new FullItemFluidStorage(context, Items.BUCKET, FluidVariant.of(bucketFluid), FluidConstants.BUCKET);
+                }
+            }
+            return null;
+        });
+
+        FluidStorage.combinedItemApiProvider(Items.BUCKET).register(context -> new EmptyItemFluidStorage(context, ItemInit.PURIFIED_BUCKET, FluidInit.PURIFIED_WATER, FluidConstants.BUCKET));
     }
 
     private static <T extends Fluid> T register(String id, T value) {


### PR DESCRIPTION
Simple solution to add compatibility with Traveler's Backpack. Registered your purified water bucket as fluid storage for purified water, so it can be stored in backpack tanks. This allows for fluid to be drinkable by hose. I'll create fluid effect for purified effect that will replenish hydration. 

It'd be nice if you'd implement this feature in older versions too, althrough I don't know if you support them. 
You'd also need to create entry in lang file for your purified water fluid so it displays the name correctly in tanks, because as for now you are missing it.

Fixes #92 