### PR TITLE
Added Thirst and Hydration effects descriptions [1.21]

### DIFF
--- a/src/main/resources/assets/dehydration/lang/en_us.json
+++ b/src/main/resources/assets/dehydration/lang/en_us.json
@@ -5,6 +5,9 @@
   "effect.dehydration.thirst_effect": "Thirst",
   "effect.dehydration.hydration_effect": "Hydration",
 
+  "effect.dehydration.thirst_effect.description": "Increases hydration depletion; higher levels accelerate dehydration.",
+  "effect.dehydration.hydration_effect.description": "Restores hydration levels; higher levels increase hydration restoration rate.",
+
   "text.autoconfig.dehydration.title": "Dehydration Config",
   "text.autoconfig.dehydration.category.default": "Default Settings",
   "text.autoconfig.dehydration.category.advanced_settings": "Advanced Settings",


### PR DESCRIPTION
I propose to add effect descriptions for your mod.

With [Stylish Effects](https://www.curseforge.com/minecraft/mc-mods/stylish-effects), the descriptions render like this:
<img src="https://github.com/user-attachments/assets/b9e946f0-4c9d-4e09-855d-a56e0b83a720">

With [JEED](https://www.curseforge.com/minecraft/mc-mods/just-enough-effect-descriptions-jeed) installed, it looks like this:
<img src="https://github.com/user-attachments/assets/dbf82468-4c8a-421b-8c6e-4dde903cb5dc" height="300"><img src="https://github.com/user-attachments/assets/8cb4ada9-6b39-4cce-b00e-45f78c570626" height="300">
