### PR TITLE
Bowl improvements

### DIFF
--- a/src/main/java/net/dehydration/block/entity/CauldronBehaviorAccess.java
+++ b/src/main/java/net/dehydration/block/entity/CauldronBehaviorAccess.java
@@ -1,0 +1,84 @@
+package net.dehydration.block.entity;
+
+import java.util.Map;
+
+import net.dehydration.init.ItemInit;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.LeveledCauldronBlock;
+import net.minecraft.block.cauldron.CauldronBehavior;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemUsage;
+import net.minecraft.item.Items;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.stat.Stats;
+import net.minecraft.util.ItemActionResult;
+import net.minecraft.world.event.GameEvent;
+
+public class CauldronBehaviorAccess {
+
+    public static void registerBehavior() {
+        Map<Item, CauldronBehavior> EMPTY_CAULDRON_BEHAVIOR_MAP = CauldronBehavior.EMPTY_CAULDRON_BEHAVIOR.map();
+        Map<Item, CauldronBehavior> WATER_CAULDRON_BEHAVIOR_MAP = CauldronBehavior.WATER_CAULDRON_BEHAVIOR.map();
+
+        CauldronBehavior EMPTY_CAULDRON_DRAIN_BOWL = (state, world, pos, player, hand, stack) -> {
+            if (!world.isClient) {
+                Item item = stack.getItem();
+                player.setStackInHand(hand, ItemUsage.exchangeStack(stack, player, new ItemStack(Items.BOWL)));
+                player.incrementStat(Stats.USE_CAULDRON);
+                player.incrementStat(Stats.USED.getOrCreateStat(item));
+                world.setBlockState(pos, Blocks.WATER_CAULDRON.getDefaultState().with(LeveledCauldronBlock.LEVEL, 2));
+                world.playSound(null, pos, SoundEvents.ITEM_BUCKET_EMPTY, SoundCategory.BLOCKS, 1.0F, 1.0F);
+                world.emitGameEvent(null, GameEvent.FLUID_PLACE, pos);
+            }
+
+            return ItemActionResult.success(world.isClient);
+        };
+        EMPTY_CAULDRON_BEHAVIOR_MAP.put(ItemInit.WATER_BOWL, EMPTY_CAULDRON_DRAIN_BOWL);
+        EMPTY_CAULDRON_BEHAVIOR_MAP.put(ItemInit.PURIFIED_WATER_BOWL, EMPTY_CAULDRON_DRAIN_BOWL);
+
+        CauldronBehavior WATER_CAULDRON_DRAIN_BOWL = (state, world, pos, player, hand, stack) -> {
+            int currentLevel = state.get(LeveledCauldronBlock.LEVEL);
+            if (LeveledCauldronBlock.MAX_LEVEL - currentLevel >= 2) {
+                if (!world.isClient) {
+                    Item item = stack.getItem();
+                    player.setStackInHand(hand, ItemUsage.exchangeStack(stack, player, new ItemStack(Items.BOWL)));
+                    player.incrementStat(Stats.USE_CAULDRON);
+                    player.incrementStat(Stats.USED.getOrCreateStat(item));
+                    world.setBlockState(pos, state.with(LeveledCauldronBlock.LEVEL, currentLevel + 2));
+                    world.playSound(null, pos, SoundEvents.ITEM_BUCKET_EMPTY, SoundCategory.BLOCKS, 1.0F, 1.0F);
+                    world.emitGameEvent(null, GameEvent.FLUID_PLACE, pos);
+                }
+
+                return ItemActionResult.success(world.isClient);
+            }
+            return ItemActionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+        };
+        WATER_CAULDRON_BEHAVIOR_MAP.put(ItemInit.WATER_BOWL, WATER_CAULDRON_DRAIN_BOWL);
+        WATER_CAULDRON_BEHAVIOR_MAP.put(ItemInit.PURIFIED_WATER_BOWL, WATER_CAULDRON_DRAIN_BOWL);
+
+        CauldronBehavior WATER_CAULDRON_FILL_BOWL = (state, world, pos, player, hand, stack) -> {
+            int currentLevel = state.get(LeveledCauldronBlock.LEVEL);
+            if (currentLevel >= 2) {
+                if (!world.isClient) {
+                    Item item = stack.getItem();
+                    player.setStackInHand(hand, ItemUsage.exchangeStack(stack, player, new ItemStack(ItemInit.WATER_BOWL)));
+                    player.incrementStat(Stats.USE_CAULDRON);
+                    player.incrementStat(Stats.USED.getOrCreateStat(item));
+                    if (currentLevel > 2) {
+                        world.setBlockState(pos, state.with(LeveledCauldronBlock.LEVEL, currentLevel - 2));
+                    } else {
+                        world.setBlockState(pos, Blocks.CAULDRON.getDefaultState());
+                    }
+                    world.playSound(null, pos, SoundEvents.ITEM_BUCKET_FILL, SoundCategory.BLOCKS, 1.0f, 1.0f);
+                    world.emitGameEvent(null, GameEvent.FLUID_PICKUP, pos);
+                }
+
+                return ItemActionResult.success(world.isClient);
+            }
+            return ItemActionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+        };
+        WATER_CAULDRON_BEHAVIOR_MAP.put(Items.BOWL, WATER_CAULDRON_FILL_BOWL);
+    }
+}

--- a/src/main/java/net/dehydration/fluid/storage/BowlFluidStorage.java
+++ b/src/main/java/net/dehydration/fluid/storage/BowlFluidStorage.java
@@ -1,0 +1,110 @@
+package net.dehydration.fluid.storage;
+
+import net.dehydration.init.FluidInit;
+import net.dehydration.init.ItemInit;
+import net.fabricmc.fabric.api.transfer.v1.context.ContainerItemContext;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.StoragePreconditions;
+import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+
+public class BowlFluidStorage extends SingleVariantStorage<FluidVariant> {
+
+    private final static long BOWL_CAPACITY = FluidConstants.BOTTLE * 2;
+
+    private final ItemStack stack;
+    private final ContainerItemContext context;
+
+    public BowlFluidStorage(ItemStack stack, ContainerItemContext context) {
+        this.stack = stack;
+        this.context = context;
+    }
+
+    @Override
+    protected FluidVariant getBlankVariant() {
+        return FluidVariant.blank();
+    }
+
+    @Override
+	public boolean isResourceBlank() {
+		return stack.isOf(Items.BOWL);
+	}
+
+	@Override
+	public FluidVariant getResource() {
+        if (stack.isOf(ItemInit.WATER_BOWL)) {
+            return FluidVariant.of(Fluids.WATER);
+        } else if (stack.isOf(ItemInit.PURIFIED_WATER_BOWL)) {
+            return FluidVariant.of(FluidInit.PURIFIED_WATER);
+        }
+		return getBlankVariant();
+	}
+
+	@Override
+	public long getAmount() {
+		return (stack.isOf(ItemInit.WATER_BOWL) || stack.isOf(ItemInit.PURIFIED_WATER_BOWL)) ? BOWL_CAPACITY : 0;
+	}
+
+    @Override
+    protected long getCapacity(FluidVariant variant) {
+        return BOWL_CAPACITY;
+    }
+
+    @Override
+    protected boolean canExtract(FluidVariant variant) {
+        if (variant.isOf(Fluids.WATER)) {
+            return stack.isOf(ItemInit.WATER_BOWL) || stack.isOf(ItemInit.PURIFIED_WATER_BOWL);
+        } else if (variant.isOf(FluidInit.PURIFIED_WATER)) {
+            return stack.isOf(ItemInit.PURIFIED_WATER_BOWL);
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean canInsert(FluidVariant variant) {
+        return stack.isOf(Items.BOWL) && (variant.getFluid() == Fluids.WATER || variant.getFluid() == FluidInit.PURIFIED_WATER);
+    }
+
+    @Override
+    public long insert(FluidVariant insertedVariant, long maxAmount, TransactionContext transaction) {
+        StoragePreconditions.notBlankNotNegative(insertedVariant, maxAmount);
+        if (!canInsert(insertedVariant)) {
+            return 0;
+        }
+        // bowls will always accept exactly BOWL_CAPACITY
+        if (maxAmount < BOWL_CAPACITY) {
+            return 0;
+        }
+
+        //exchange item
+        ItemStack newStack = new ItemStack(insertedVariant.isOf(FluidInit.PURIFIED_WATER) ? ItemInit.PURIFIED_WATER_BOWL : ItemInit.WATER_BOWL);
+        if (context.exchange(ItemVariant.of(newStack), 1, transaction) == 1) {
+            return BOWL_CAPACITY;
+        }
+        return 0;
+    }
+
+    @Override
+    public long extract(FluidVariant extractedVariant, long maxAmount, TransactionContext transaction) {
+        StoragePreconditions.notBlankNotNegative(extractedVariant, maxAmount);
+        if (!canExtract(extractedVariant)) {
+            return 0;
+        }
+        // bowls will always accept exactly BOWL_CAPACITY
+        if (maxAmount < BOWL_CAPACITY) {
+            return 0;
+        }
+
+        //exchange item
+        ItemStack newStack = new ItemStack(Items.BOWL);
+        if (context.exchange(ItemVariant.of(newStack), 1, transaction) == 1) {
+            return BOWL_CAPACITY;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/net/dehydration/init/EventInit.java
+++ b/src/main/java/net/dehydration/init/EventInit.java
@@ -8,6 +8,7 @@ import net.dehydration.thirst.ThirstManager;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
 import net.fabricmc.fabric.api.loot.v3.LootTableEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.registry.FabricBrewingRecipeRegistryBuilder;
@@ -28,6 +29,7 @@ import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
@@ -62,32 +64,40 @@ public class EventInit {
             }
         });
 
-        UseBlockCallback.EVENT.register((player, world, hand, result) -> {
-            if (!player.isCreative() && !player.isSpectator() && player.isSneaking() && (player.getMainHandStack().isEmpty() || player.getMainHandStack().isOf(Items.BOWL))) {
-                HitResult hitResult = player.raycast(1.5D, 0.0F, true);
+        UseItemCallback.EVENT.register((player, world, hand) -> {
+            if (!player.isCreative() && !player.isSpectator() && player.isSneaking() && player.getStackInHand(hand).isOf(Items.BOWL)) {
+                HitResult hitResult = player.raycast(player.getBlockInteractionRange(), 0.0F, true);
                 BlockPos blockPos = ((BlockHitResult) hitResult).getBlockPos();
                 if (world.canPlayerModifyAt(player, blockPos) && world.getFluidState(blockPos).isIn(FluidTags.WATER)) {
-                    if (player.getMainHandStack().isOf(Items.BOWL)) {
-                        if (world.getFluidState(blockPos).isStill()) {
-                            world.playSound(null, blockPos, SoundEvents.ITEM_BUCKET_FILL, SoundCategory.BLOCKS, 1.0f, 1.0f);
-                            if (!world.isClient()) {
-                                ItemStack itemStack = new ItemStack(ItemInit.WATER_BOWL);
-                                if (world.getFluidState(blockPos).isIn(TagInit.PURIFIED_WATER)) {
-                                    itemStack = new ItemStack(ItemInit.PURIFIED_WATER_BOWL);
-                                }
-                                player.setStackInHand(hand, ItemUsage.exchangeStack(player.getMainHandStack(), player, itemStack));
-                                player.incrementStat(Stats.USED.getOrCreateStat(player.getMainHandStack().getItem()));
-                                if (world.getBlockState(blockPos).contains(Properties.WATERLOGGED)) {
-                                    world.setBlockState(blockPos, world.getBlockState(blockPos).with(Properties.WATERLOGGED, false));
-                                } else {
-                                    world.setBlockState(blockPos, Blocks.AIR.getDefaultState());
-                                }
+                    if (world.getFluidState(blockPos).isStill()) {
+                        world.playSound(null, blockPos, SoundEvents.ITEM_BUCKET_FILL, SoundCategory.BLOCKS, 1.0f, 1.0f);
+                        if (!world.isClient()) {
+                            ItemStack itemStack = new ItemStack(ItemInit.WATER_BOWL);
+                            if (world.getFluidState(blockPos).isIn(TagInit.PURIFIED_WATER)) {
+                                itemStack = new ItemStack(ItemInit.PURIFIED_WATER_BOWL);
                             }
-                            return ActionResult.SUCCESS;
-                        } else {
-                            return ActionResult.PASS;
+                            player.setStackInHand(hand, ItemUsage.exchangeStack(player.getStackInHand(hand), player, itemStack));
+                            player.incrementStat(Stats.USED.getOrCreateStat(player.getStackInHand(hand).getItem()));
+                            if (world.getBlockState(blockPos).contains(Properties.WATERLOGGED)) {
+                                world.setBlockState(blockPos, world.getBlockState(blockPos).with(Properties.WATERLOGGED, false));
+                            } else {
+                                world.setBlockState(blockPos, Blocks.AIR.getDefaultState());
+                            }
                         }
+                        return TypedActionResult.success(player.getStackInHand(hand), true);
+                    } else {
+                        return TypedActionResult.pass(player.getStackInHand(hand));
                     }
+                }
+            }
+            return TypedActionResult.pass(player.getStackInHand(hand));
+        });
+        
+        UseBlockCallback.EVENT.register((player, world, hand, result) -> {
+            if (!player.isCreative() && !player.isSpectator() && player.isSneaking() && player.getMainHandStack().isEmpty()) {
+                HitResult hitResult = player.raycast(player.getBlockInteractionRange(), 0.0F, true);
+                BlockPos blockPos = ((BlockHitResult) hitResult).getBlockPos();
+                if (world.canPlayerModifyAt(player, blockPos) && world.getFluidState(blockPos).isIn(FluidTags.WATER)) {
                     if (world.getFluidState(blockPos).isStill() || ConfigInit.CONFIG.allow_non_flowing_water_sip) {
                         ThirstManager thirstManager = ((ThirstManagerAccess) player).getThirstManager();
                         if (thirstManager.isNotFull()) {
@@ -126,7 +136,6 @@ public class EventInit {
                         }
                     }
                 }
-                return ActionResult.PASS;
             }
             return ActionResult.PASS;
         });

--- a/src/main/java/net/dehydration/init/FluidInit.java
+++ b/src/main/java/net/dehydration/init/FluidInit.java
@@ -2,6 +2,7 @@ package net.dehydration.init;
 
 import net.dehydration.block.entity.CampfireCauldronEntity;
 import net.dehydration.fluid.PurifiedWaterFluid;
+import net.dehydration.fluid.storage.BowlFluidStorage;
 import net.dehydration.fluid.storage.CampfireCauldronFluidStorage;
 import net.dehydration.fluid.storage.CopperCauldronFluidStorage;
 import net.dehydration.fluid.storage.LeatherFlaskFluidStorage;
@@ -37,6 +38,8 @@ public class FluidInit {
         FluidStorage.combinedItemApiProvider(Items.POTION).register(PurifiedWaterPotionStorage::find);
         // Register flask storage
         FluidStorage.ITEM.registerForItems((itemStack, context) -> new LeatherFlaskFluidStorage(context), ItemInit.LEATHER_FLASK, ItemInit.IRON_LEATHER_FLASK, ItemInit.GOLDEN_LEATHER_FLASK, ItemInit.DIAMOND_LEATHER_FLASK, ItemInit.NETHERITE_LEATHER_FLASK);
+        // Register bowl storage
+        FluidStorage.ITEM.registerForItems((itemStack, context) -> new BowlFluidStorage(itemStack, context), Items.BOWL, ItemInit.WATER_BOWL, ItemInit.PURIFIED_WATER_BOWL);
         // Register campfire cauldron storage
         FluidStorage.SIDED.registerForBlocks((world, pos, state, blockEntity, context) -> new CampfireCauldronFluidStorage(world, pos, state, (CampfireCauldronEntity) blockEntity), BlockInit.CAMPFIRE_CAULDRON_BLOCK);
         //register copper cauldron fluid storage

--- a/src/main/java/net/dehydration/item/WaterBowlItem.java
+++ b/src/main/java/net/dehydration/item/WaterBowlItem.java
@@ -10,14 +10,22 @@ import net.dehydration.misc.ThirstTooltipData;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.fluid.FluidState;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUsage;
 import net.minecraft.item.Items;
 import net.minecraft.item.tooltip.TooltipData;
+import net.minecraft.registry.tag.FluidTags;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.UseAction;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.RaycastContext;
 import net.minecraft.world.World;
 
 public class WaterBowlItem extends Item {
@@ -69,6 +77,15 @@ public class WaterBowlItem extends Item {
 
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
+        BlockHitResult hitResult = raycast(world, user, RaycastContext.FluidHandling.SOURCE_ONLY);
+        BlockPos blockPos = hitResult.getBlockPos();
+
+        FluidState fluidState = world.getFluidState(blockPos);
+        if (hitResult.getType() == HitResult.Type.BLOCK && world.canPlayerModifyAt(user, blockPos) && fluidState.isIn(FluidTags.WATER) && user.isSneaking()) {
+            world.playSound(user, user.getX(), user.getY(), user.getZ(), SoundEvents.ITEM_BUCKET_EMPTY, SoundCategory.NEUTRAL, 1.0F, 1.0F);
+            return TypedActionResult.consume(new ItemStack(Items.BOWL));
+        }
+
         return ItemUsage.consumeHeldItem(world, user, hand);
     }
 

--- a/src/main/java/net/dehydration/mixin/BootstrapMixin.java
+++ b/src/main/java/net/dehydration/mixin/BootstrapMixin.java
@@ -6,6 +6,7 @@ import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.At;
 
+import net.dehydration.block.entity.CauldronBehaviorAccess;
 import net.dehydration.block.entity.CopperCauldronBehavior;
 import net.dehydration.block.entity.DispenserBehaviorAccess;
 import net.minecraft.Bootstrap;
@@ -16,6 +17,7 @@ public class BootstrapMixin {
     @Inject(method = "initialize", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/dispenser/DispenserBehavior;registerDefaults()V", shift = Shift.AFTER))
     private static void initializeMixin(CallbackInfo info) {
         DispenserBehaviorAccess.registerDefaults();
+        CauldronBehaviorAccess.registerBehavior();
         CopperCauldronBehavior.registerBehavior();
     }
 }

--- a/src/main/resources/data/dehydration/recipe/pour_purified_water_bowl.json
+++ b/src/main/resources/data/dehydration/recipe/pour_purified_water_bowl.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+      {
+        "item": "dehydration:purified_water_bowl"
+      }
+    ],
+    "result": {
+      "id": "minecraft:bowl"
+    }
+  }

--- a/src/main/resources/data/dehydration/recipe/pour_water_bowl.json
+++ b/src/main/resources/data/dehydration/recipe/pour_water_bowl.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+      {
+        "item": "dehydration:water_bowl"
+      }
+    ],
+    "result": {
+      "id": "minecraft:bowl"
+    }
+  }


### PR DESCRIPTION
I changed several things about bowls in this PR.

* Registered a simple fluid storage for bowls that allows them to interact with the copper cauldron's fluid api. It basically switches between item on "insert" and "extract".
* Added behaviors to vanilla cauldrons so that bowls can also insert/extract from them
* Changed bowls to use an item use event instead of a block use event so that the water targeting works better
* Added action to dump bowls when shift-clicking on water
* Added shapeless recipes to craft water bowls into a bowls