### PR TITLE
Let snow precipitation add to campfire cauldron's water level

### DIFF
--- a/src/main/java/net/dehydration/block/CampfireCauldronBlock.java
+++ b/src/main/java/net/dehydration/block/CampfireCauldronBlock.java
@@ -101,8 +101,8 @@ public class CampfireCauldronBlock extends Block implements BlockEntityProvider 
 
     @Override
     public void precipitationTick(BlockState state, World world, BlockPos pos, Biome.Precipitation precipitation) {
-        if (world.getRandom().nextFloat() < 0.2f && world.isSkyVisible(pos) && world.getBiome(pos).value().getTemperature() >= 0.15F && world.getBiome(pos).value().getTemperature() < 2F) {
-            if (precipitation == Biome.Precipitation.RAIN && state.get(LEVEL) < 4) {
+        if (CopperCauldronBlock.canFillWithPrecipitation(world, precipitation)) {
+            if (state.get(LEVEL) < 4) {
                 this.setLevel(world, pos, state, state.get(LEVEL) + 1);
                 world.emitGameEvent(null, GameEvent.FLUID_PLACE, pos);
             }


### PR DESCRIPTION
Just a suggestion.

Since the campfire cauldron is heated, it shouldn't matter whether rain or snow falls into it. It will all raise the water (or purified water) level of the cauldron.